### PR TITLE
refactor: separate prompting from the Generator class for reusability

### DIFF
--- a/generators/app/prompting.js
+++ b/generators/app/prompting.js
@@ -1,0 +1,19 @@
+module.exports = (gen, params, optionNames) => {
+  const questions = params.getQuestions(gen);
+  const invQuestions = {};
+  questions.forEach(question => {
+    invQuestions[question.name] = question;
+  });
+  return gen.prompt(questions).then(answers => {
+    const ret = {};
+    optionNames.forEach(name => {
+      if (gen.options[name] !== undefined) {
+        const filter = invQuestions[name].filter;
+        ret[name] = filter ? filter(gen.options[name]) : gen.options[name];
+      } else {
+        ret[name] = answers[name];
+      }
+    });
+    gen.answers = ret;
+  });
+};


### PR DESCRIPTION
yeoman generator is designed not to use prompting in sub generators,
so the prompting implementation should be separated from the Generator class.